### PR TITLE
Fix J!1.0 non-latin import and try harder to keep the menu aliases the same

### DIFF
--- a/trunk/admin/includes/jupgrade.category.class.php
+++ b/trunk/admin/includes/jupgrade.category.class.php
@@ -74,7 +74,9 @@ class jUpgradeCategory extends jUpgrade
 		{
 			$row['params'] = $this->convertParams($row['params']);
 			$row['access'] = $row['access'] == 0 ? 1 : $row['access'] + 1;
-			$row['title'] = str_replace("'", "&#39;", $row['title']);
+
+			// Convert HTML entities to UTF-8 on escaped entries
+			$row['title'] = $this->entities2Utf8($row['title']);
 			$row['description'] = str_replace("'", "&#39;", $row['description']);
 			$row['language'] = '*';
 

--- a/trunk/admin/includes/jupgrade.class.php
+++ b/trunk/admin/includes/jupgrade.class.php
@@ -534,7 +534,17 @@ class jUpgrade
 		echo str_replace("=>","&#8658;",str_replace("Array","<font color=\"red\"><b>Array</b></font>",nl2br(str_replace(" "," &nbsp; ",print_r($subject,true)))));
 	}
 
-
+	/**
+	 * Internal function to convert numeric html entities to UTF-8.
+	 *
+	 * @return	string
+	 * @since	2.5.2
+	 */
+	public function entities2Utf8($input)
+	{
+		return html_entity_decode($input, ENT_QUOTES, 'UTF-8');
+	}
+	
 	/**
 	 * Internal function to get original database prefix
 	 *

--- a/trunk/admin/includes/migrate_banners.php
+++ b/trunk/admin/includes/migrate_banners.php
@@ -54,6 +54,9 @@ class jUpgradeBanners extends jUpgrade
 	        // Do some custom post processing on the list.
 	        foreach ($rows as $index => &$row)
 	        {    
+	        		// Convert HTML entities to UTF-8 on escaped entries
+	        		$row['name'] = $this->entities2Utf8($row['name']);
+	        	
 	                $row['params'] = $this->convertParams($row['params']);                        
 
 	                $cid = $row['catid'];

--- a/trunk/admin/includes/migrate_categories.php
+++ b/trunk/admin/includes/migrate_categories.php
@@ -127,7 +127,7 @@ class jUpgradeCategories extends jUpgradeCategory
 		if (!empty($jconfig->cli) && $jconfig->cli == 1) {
 			$helperpath = JPATH_BASE;
 		}else{
-			$helperpath = JPATH_BASE.'/administrator/components/com_jupgrade';
+			$helperpath = JPATH_ROOT.'/administrator/components/com_jupgrade';
 		}
 
 		// Require the files

--- a/trunk/admin/includes/migrate_categories.php
+++ b/trunk/admin/includes/migrate_categories.php
@@ -137,9 +137,10 @@ class jUpgradeCategories extends jUpgradeCategory
 		$sqlfile = $helperpath.'/sql/categories.sql';
 
 		// Import the sql file
-	  if (JUpgradeHelper::populateDatabase($this->db_new, $sqlfile, $errors) > 0 ) {
-	  	return false;
-	  }
+		$errors = array();
+		if (JUpgradeHelper::populateDatabase($this->db_new, $sqlfile, $errors) > 0 ) {
+			return false;
+		}
 
 	} // end method
 } // end class

--- a/trunk/admin/includes/migrate_content.php
+++ b/trunk/admin/includes/migrate_content.php
@@ -67,6 +67,12 @@ class jUpgradeContent extends jUpgrade
 		// Do some custom post processing on the list.
 		foreach ($rows as &$row)
 		{
+			// Convert HTML entities to UTF-8 on escaped entries
+			$row['title'] = $this->entities2Utf8($row['title']);
+			$row['created_by_alias'] = $this->entities2Utf8($row['created_by_alias']);
+			$row['metakey'] = $this->entities2Utf8($row['metakey']);
+			$row['metadesc'] = $this->entities2Utf8($row['metadesc']);
+			
 			$row['attribs'] = $this->convertParams($row['attribs']);
 			$row['access'] = $row['access'] == 0 ? 1 : $row['access'] + 1;
 			$row['language'] = '*';

--- a/trunk/admin/includes/migrate_menus.php
+++ b/trunk/admin/includes/migrate_menus.php
@@ -70,7 +70,6 @@ class jUpgradeMenu extends jUpgrade
  
 		// Initialize values
 		$aliases = array();
-		$unique_alias_suffix = 1;
  
 		// Do some custom post processing on the list.
 		foreach ($rows as $key => &$row) {
@@ -131,12 +130,14 @@ class jUpgradeMenu extends jUpgrade
       // Converting params to JSON
       $row['params'] = $this->convertParams($row['params']);
 
-      // The Joomla 1.6 database structure does not allow duplicate aliases
-      if (in_array($row['alias'], $aliases, true)) {
-        $row['alias'] .= $unique_alias_suffix;
-        $unique_alias_suffix++;
+      // The Joomla 2.5 database structure does not allow duplicate aliases
+      $key = $row['parent_id'].' '.$row['alias'].' '.$row['language'];
+      if (isset($aliases[$key])) {
+      	// Change alias and key
+        $row['alias'] .= '-'.$row['id'];
+        $key = $row['parent_id'].' '.$row['alias'].' '.$row['language'];
       }
-      $aliases[] = $row['alias'];
+      $aliases[$key] = 1;
     }
 
 		return $rows;

--- a/trunk/admin/includes/migrate_menus.php
+++ b/trunk/admin/includes/migrate_menus.php
@@ -215,9 +215,10 @@ class jUpgradeMenu extends jUpgrade
 		$sqlfile = JPATH_ROOT.DS.'administrator'.DS.'components'.DS.'com_jupgrade'.DS.'sql'.DS.'menus.sql';
 
 		// Import the sql file
-	  if (JUpgradeHelper::populateDatabase($this->db_new, $sqlfile, $errors) > 0 ) {
-	  	return false;
-	  }
+		$errors = array();
+		if (JUpgradeHelper::populateDatabase($this->db_new, $sqlfile, $errors) > 0 ) {
+			return false;
+		}
 	}
 
 	/**

--- a/trunk/admin/includes/migrate_menus.php
+++ b/trunk/admin/includes/migrate_menus.php
@@ -74,7 +74,9 @@ class jUpgradeMenu extends jUpgrade
  
 		// Do some custom post processing on the list.
 		foreach ($rows as $key => &$row) {
- 
+			// Convert HTML entities to UTF-8 on escaped entries
+			$row['title'] = $this->entities2Utf8($row['title']);
+
 			// Fixing access
 			$row['access']++;
 			// Fixing level

--- a/trunk/admin/includes/migrate_modules.php
+++ b/trunk/admin/includes/migrate_modules.php
@@ -98,6 +98,9 @@ class jUpgradeModules extends jUpgrade
 		// Do some custom post processing on the list.
 		foreach ($rows as &$row)
 		{
+			// Convert HTML entities to UTF-8 on escaped entries
+			$row['title'] = $this->entities2Utf8($row['title']);
+
 			$row['params'] = $this->convertParams($row['params']);
 
 			## Fix access

--- a/trunk/admin/includes/migrate_newsfeeds.php
+++ b/trunk/admin/includes/migrate_newsfeeds.php
@@ -48,6 +48,9 @@ class jUpgradeNewsfeeds extends jUpgrade
 		// Do some custom post processing on the list.
 		foreach ($rows as &$row)
 		{
+			// Convert HTML entities to UTF-8 on escaped entries
+			$row['name'] = $this->entities2Utf8($row['name']);
+			
 			$row['access'] = empty($row['access']) ? 1 : $row['access'] + 1;
 			$row['language'] = '*';
 

--- a/trunk/admin/includes/migrate_weblinks.php
+++ b/trunk/admin/includes/migrate_weblinks.php
@@ -48,6 +48,9 @@ class jUpgradeWeblinks extends jUpgrade
 		// Do some custom post processing on the list.
 		foreach ($rows as &$row)
 		{
+			// Convert HTML entities to UTF-8 on escaped entries
+			$row['title'] = $this->entities2Utf8($row['title']);
+			
 			$row['params'] = $this->convertParams($row['params']);
 
 			$cid = $row['catid'];


### PR DESCRIPTION
Fix htmlencoded strings which are escaped in J!2.5
- In some old Joomla! 1.0 sites languages like Japanese were using HTML entities. This doesn't work in Joomla! 2.5 anymore, so those need to be fixed. Also fixes other entities, like &amp;

Fix fatal error when migrating categories (component only)
- One of the last commits broke the component.

Improve code readability on error handling (category, menu migration)
- I've alwas wondered what the variable $errors was.

Fix menu aliases generation where there was no reason to rename alias
- If site had say 6 languages and all of them had the same menus with same aliases, none of the old aliases will work, even if they were totally legal. The new implementation does the same check as Joomla! itself, thus allowing most of the aliases to remain the same.

PS: if someone wants to get the old aliases on already migrated site, you could run something like this:

```
UPDATE IGNORE j25_menu AS s INNER JOIN jos_menu AS j ON s.id=j.id AND s.client_id=0 AND s.alias != j.alias SET s.alias=j.alias
```
